### PR TITLE
Add 3 test cases for FFmpeg

### DIFF
--- a/test_cases/ffmpeg/testing_api/redditrpan_studio_av_frame_alloc_a374e7e.c
+++ b/test_cases/ffmpeg/testing_api/redditrpan_studio_av_frame_alloc_a374e7e.c
@@ -1,0 +1,32 @@
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+
+struct enc_encoder {
+    AVFrame *aframe;
+};
+
+int Test_initialize_codec() {
+    struct enc_encoder enc;
+    int ret;
+
+    // Initialize network components
+    avformat_network_init();
+
+    // Allocate memory for AVFrame
+    AVFrame *allocated_frame = av_frame_alloc();
+    enc.aframe = allocated_frame;
+
+    // Check if allocation was successful
+    if (!enc.aframe) {
+        return -1;
+    }
+
+    // Clean up
+    av_frame_free(&enc.aframe);
+
+    return 0;
+}
+
+int main() {
+    return Test_initialize_codec();
+}

--- a/test_cases/ffmpeg/testing_api/redditrpan_studio_av_freep_443472d.c
+++ b/test_cases/ffmpeg/testing_api/redditrpan_studio_av_freep_443472d.c
@@ -1,0 +1,34 @@
+#include <libavutil/frame.h>
+#include <libavutil/mem.h>
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+struct enc_encoder {
+    uint8_t *samples[1];
+    AVFrame *aframe;
+};
+
+int Test_enc_destroy() {
+    // Initialize function parameters
+    struct enc_encoder enc;
+    enc.samples[0] = (uint8_t *)av_malloc(100); // Allocate memory for the sample
+    enc.aframe = av_frame_alloc(); // Allocate an AVFrame
+
+    // Free the first sample if it exists
+    uint8_t *first_sample = enc.samples[0];
+    if (first_sample) {
+        av_freep(&enc.samples[0]);
+    }
+
+    // Free the audio frame if it exists
+    AVFrame *audio_frame = enc.aframe;
+    if (audio_frame) {
+        av_frame_free(&enc.aframe);
+    }
+
+    return 0;
+}
+
+int main() {
+    return Test_enc_destroy();
+}

--- a/test_cases/ffmpeg/testing_api/redditrpan_studio_avcodec_fill_audio_frame_fd91cdb.c
+++ b/test_cases/ffmpeg/testing_api/redditrpan_studio_avcodec_fill_audio_frame_fd91cdb.c
@@ -1,0 +1,88 @@
+#include <libavcodec/avcodec.h>
+#include <libavutil/avutil.h>
+#include <libavutil/opt.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/samplefmt.h>
+#include <libavutil/mem.h>
+
+struct enc_encoder {
+    AVCodecContext *context;
+    AVFrame *aframe;
+    int64_t total_samples;
+    uint8_t **samples;
+    int frame_size_bytes;
+};
+
+int Test_do_encode() {
+    // Initialize encoder structure
+    struct enc_encoder enc;
+    enc.context = avcodec_alloc_context3(NULL);
+    if (!enc.context) {
+        return -1;
+    }
+
+    // Set up context parameters (example values)
+    enc.context->sample_rate = 44100;
+    enc.context->channels = 2;
+    enc.context->sample_fmt = AV_SAMPLE_FMT_FLTP;
+    enc.context->channel_layout = AV_CH_LAYOUT_STEREO;
+    enc.context->time_base = (AVRational){1, enc.context->sample_rate};
+
+    // Allocate frame
+    enc.aframe = av_frame_alloc();
+    if (!enc.aframe) {
+        avcodec_free_context(&enc.context);
+        return -1;
+    }
+
+    // Set frame parameters
+    enc.aframe->nb_samples = enc.context->frame_size;
+    enc.aframe->format = enc.context->sample_fmt;
+    enc.aframe->channel_layout = enc.context->channel_layout;
+
+    // Allocate buffer for samples
+    enc.frame_size_bytes = av_samples_get_buffer_size(NULL, enc.context->channels, enc.context->frame_size, enc.context->sample_fmt, 0);
+    enc.samples = (uint8_t **)av_mallocz(enc.context->channels * sizeof(*enc.samples));
+    if (!enc.samples) {
+        av_frame_free(&enc.aframe);
+        avcodec_free_context(&enc.context);
+        return -1;
+    }
+    av_samples_alloc(enc.samples, NULL, enc.context->channels, enc.context->frame_size, enc.context->sample_fmt, 0);
+
+    // Initialize time base and packet
+    AVRational time_base = {1, enc.context->sample_rate};
+    AVPacket avpacket;
+    av_init_packet(&avpacket);
+
+    // Rescale total samples
+    int64_t rescaled_samples = av_rescale_q(
+        enc.total_samples, (AVRational){1, enc.context->sample_rate},
+        enc.context->time_base);
+
+    // Fill audio frame
+    int ret = avcodec_fill_audio_frame(
+        enc.aframe, enc.context->channels, enc.context->sample_fmt,
+        enc.samples[0], enc.frame_size_bytes * enc.context->channels, 1);
+
+    // Check for errors
+    if (ret < 0) {
+        av_freep(&enc.samples[0]);
+        av_freep(&enc.samples);
+        av_frame_free(&enc.aframe);
+        avcodec_free_context(&enc.context);
+        return 0;
+    }
+
+    // Clean up
+    av_freep(&enc.samples[0]);
+    av_freep(&enc.samples);
+    av_frame_free(&enc.aframe);
+    avcodec_free_context(&enc.context);
+
+    return 0;
+}
+
+int main() {
+    return Test_do_encode();
+}


### PR DESCRIPTION
## Multiple Test Cases Addition

**Library:** FFmpeg
**Total Test Cases:** 3
**Target APIs:** Testing_API

### Coverage Summary

| Test Case | Target API | Coverage Before | Coverage After | Improvement | Covered Lines Change |
|-----------|------------|-----------------|----------------|-------------|---------------------|
| redditrpan-studio_av_freep_443472d | Testing_API | 0.0% | 0.0% | +0.0% | +0 |
| redditrpan-studio_av_frame_alloc_a374e7e | Testing_API | 0.0% | 100.0% | +100.0% | +20 |
| redditrpan-studio_avcodec_fill_audio_frame_fd91cdb | Testing_API | 0.0% | 0.0% | +0.0% | +40 |


### Test Case Details

This PR adds 3 new test cases generated by the CodeSA TestGeneration system to improve test coverage for multiple APIs in the FFmpeg library.

